### PR TITLE
Add support for greedy meshing, 4-tap, reconfiguring, and non-atlas texturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ View [the demo](http://shama.github.com/voxel-texture).
 
 **ATTENTION! v0.5.0 has changed dramatically. This library is no longer is
 materials API but just loads textures onto an atlas and sets UV mappings.**
+The old API without atlases can be enabled by setting the 'useAtlas' option to false.
 
 ## example
 

--- a/index.js
+++ b/index.js
@@ -367,16 +367,13 @@ Texture.prototype.pack = function(name, done) {
       if (isTransparent(img)) {
         self.transparents.push(name);
       }
-      if (self.useFourTap) {
-        // repeat 2x2 for mipmap padding 4-tap trick
-        var img2 = new Image();
-        img2.id = name;
-        img2.src = touchup.repeat(img, 2, 2);
-        img2.onload = function() {
-          pack(img2);
-        }
-      } else {
-        pack(img);
+      // repeat 2x2 for mipmap padding 4-tap trick
+      // TODO: replace with atlaspack padding, but changed to 2x2: https://github.com/deathcap/atlaspack/tree/tilepadamount
+      var img2 = new Image();
+      img2.id = name;
+      img2.src = touchup.repeat(img, 2, 2);
+      img2.onload = function() {
+        pack(img2);
       }
     }, function(err, img) {
       console.error('Couldn\'t load URL [' + img.src + ']');

--- a/index.js
+++ b/index.js
@@ -112,6 +112,10 @@ Texture.prototype.load = function(names, done) {
   }
 };
 
+Texture.prototype.getMesh = function() {
+  return this.materials.material;
+}
+
 Texture.prototype.pack = function(name, done) {
   var self = this;
   function pack(img) {
@@ -157,6 +161,8 @@ Texture.prototype.find = function(name) {
   });
   return type;
 };
+
+Texture.prototype.findIndex = Texture.prototype.find; // compatibility
 
 Texture.prototype._expandName = function(name) {
   if (name === null) return Array(6);
@@ -217,6 +223,10 @@ Texture.prototype._powerof2 = function(done) {
   this.canvas.width = this.canvas.height = pow2(w);
   this.canvas.getContext('2d').putImageData(old, 0, 0);
   done();
+};
+
+Texture.prototype.paintMesh = function(mesh) {
+  this.paint(mesh);
 };
 
 Texture.prototype.paint = function(mesh, materials) {
@@ -434,6 +444,10 @@ TextureSimple.prototype.load = function(names, opts) {
   }));
 };
 
+TextureSimple.prototype.getMesh = function() {
+  return new this.THREE.MeshFaceMaterial(this.get());
+};
+
 TextureSimple.prototype.get = function(index) {
   if (index == null) return this.materials;
   if (typeof index === 'number') {
@@ -482,6 +496,10 @@ TextureSimple.prototype._options = function(opts) {
   opts.materialParams = defaults(opts.materialParams || {}, this._materialDefaults, this.materialParams);
   opts.applyTextureParams = opts.applyTextureParams || this.applyTextureParams;
   return opts;
+};
+
+TextureSimple.prototype.paintMesh = function(mesh) {
+  this.paint(mesh.geometry);
 };
 
 TextureSimple.prototype.paint = function(geom) {

--- a/index.js
+++ b/index.js
@@ -651,7 +651,7 @@ function TextureSimple(game, opts) {
     map.wrapS     = self.THREE.RepeatWrapping;
   };
 
-  this.THREE              = this.game.THREE || opts.THREE || require('three');
+  this.THREE              = this.game.THREE || opts.THREE;
   this.materials          = [];
   this.names              = [];
   this.texturePath        = opts.texturePath    || '/textures/';

--- a/index.js
+++ b/index.js
@@ -283,17 +283,13 @@ function Texture(game, opts) {
       //depthWrite: false,
       //depthTest: false
       // TODO
-    },
-    materialType: this.THREE.ShaderMaterial,
-    applyTextureParams: function(map) {
-      map.magFilter = self.THREE.NearestFilter;
-      map.minFilter = self.THREE.LinearMipMapLinearFilter;
     }
   };
 
   this.options.materialParams.lights = []; // force lights refresh to setup uniforms, three.js WebGLRenderer line 4323
   this.options.materialParams.uniforms.tileMap.value = this.texture;
-  this.options.applyTextureParams(this.texture);
+  this.texture.magFilter = this.THREE.NearestFilter;
+  this.texture.minFilter = this.THREE.LinearMipMapLinearFilter;
 
   if (useFlatColors) {
     // If were using simple colors
@@ -301,8 +297,8 @@ function Texture(game, opts) {
       vertexColors: this.THREE.VertexColors
     });
   } else {
-    var opaque = new this.options.materialType(this.options.materialParams);
-    var transparent = new this.options.materialType(this.options.materialTransparentParams);
+    var opaque = new this.THREE.ShaderMaterial(this.options.materialParams);
+    var transparent = new this.THREE.ShaderMaterial(this.options.materialTransparentParams);
     this.material = new this.THREE.MeshFaceMaterial([
       opaque,
       transparent

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var createAtlas = require('atlaspack');
 var isTransparent = require('opaque').transparent;
 
 module.exports = function(game, opts) {
-  if (opts === undefined) opts = game;
-
+  opts = opts || {};
+    
   opts.useAtlas = (opts.useAtlas === undefined) ? true : opts.useAtlas;
 
   if (opts.useAtlas)
@@ -13,10 +13,10 @@ module.exports = function(game, opts) {
     return new TextureSimple(game, opts);
 };
 
-function Texture(opts) {
-  if (!(this instanceof Texture)) return new Texture(opts || {});
+function Texture(game, opts) {
+  if (!(this instanceof Texture)) return new Texture(game, opts || {});
   var self = this;
-  this.game = opts.game; delete opts.game;
+  this.game = game;
   this.THREE = this.game.THREE;
   this.materials = [];
   this.transparents = [];
@@ -395,10 +395,11 @@ function each(arr, it, done) {
 // Support for textures without atlas ("simple" textures), as in 0.4.0
 ////
 
-function TextureSimple(opts) {
+function TextureSimple(game, opts) {
+  if (!(this instanceof TextureSimple)) return new TextureSimple(game, opts || {});
   var self = this;
-  if (!(this instanceof TextureSimple)) return new TextureSimple(opts || {});
-  this.THREE              = opts.THREE          || require('three');
+  this.game = game;
+  this.THREE              = this.game.THREE || opts.THREE || require('three');
   this.materials          = [];
   this.texturePath        = opts.texturePath    || '/textures/';
   this.materialParams     = opts.materialParams || {};
@@ -413,6 +414,7 @@ function TextureSimple(opts) {
     map.wrapS     = self.THREE.RepeatWrapping;
   }
 }
+
 TextureSimple.prototype.load = function(names, opts) {
   var self = this;
   opts = self._options(opts);

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ Texture.prototype.load = function(names, done) {
 };
 
 Texture.prototype.getMesh = function() {
-  return this.materials.material;
+  return this.material;
 }
 
 Texture.prototype.pack = function(name, done) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,17 @@ var tic = require('tic')();
 var createAtlas = require('atlaspack');
 var isTransparent = require('opaque').transparent;
 
+module.exports = function(game, opts) {
+  if (opts === undefined) opts = game;
+
+  opts.useAtlas = (opts.useAtlas === undefined) ? true : opts.useAtlas;
+
+  if (opts.useAtlas)
+    return new Texture(game, opts);
+  else
+    return new TextureSimple(game, opts);
+};
+
 function Texture(opts) {
   if (!(this instanceof Texture)) return new Texture(opts || {});
   var self = this;
@@ -72,7 +83,6 @@ function Texture(opts) {
   // a place for meshes to wait while textures are loading
   this._meshQueue = [];
 }
-module.exports = Texture;
 
 Texture.prototype.load = function(names, done) {
   var self = this;
@@ -369,4 +379,223 @@ function each(arr, it, done) {
       if (count >= arr.length) done();
     });
   });
+}
+
+////
+// Support for textures without atlas ("simple" textures), as in 0.4.0
+////
+
+var transparent = require('opaque').transparent;
+
+function TextureSimple(opts) {
+  var self = this;
+  if (!(this instanceof TextureSimple)) return new TextureSimple(opts || {});
+  this.THREE              = opts.THREE          || require('three');
+  this.materials          = [];
+  this.texturePath        = opts.texturePath    || '/textures/';
+  this.materialParams     = opts.materialParams || {};
+  this.materialType       = opts.materialType   || this.THREE.MeshLambertMaterial;
+  this.materialIndex      = [];
+  this._animations        = [];
+  this._materialDefaults  = { ambient: 0xbbbbbb };
+  this.applyTextureParams = opts.applyTextureParams || function(map) {
+    map.magFilter = self.THREE.NearestFilter;
+    map.minFilter = self.THREE.LinearMipMapLinearFilter;
+    map.wrapT     = self.THREE.RepeatWrapping;
+    map.wrapS     = self.THREE.RepeatWrapping;
+  }
+}
+TextureSimple.prototype.load = function(names, opts) {
+  var self = this;
+  opts = self._options(opts);
+  if (!isArray(names)) names = [names];
+  if (!hasSubArray(names)) names = [names];
+  return [].concat.apply([], names.map(function(name) {
+    name = self._expandName(name);
+    self.materialIndex.push([self.materials.length, self.materials.length + name.length]);
+    return name.map(function(n) {
+      if (n instanceof self.THREE.Texture) {
+        var map = n;
+        n = n.name;
+      } else if (typeof n === 'string') {
+        var map = self.THREE.ImageUtils.loadTexture(self.texturePath + ext(n));
+      } else {
+        var map = new self.THREE.Texture(n);
+        n = map.name;
+      }
+      self.applyTextureParams.call(self, map);
+      var mat = new opts.materialType(opts.materialParams);
+      mat.map = map;
+      mat.name = n;
+      if (opts.transparent == null) self._isTransparent(mat);
+      self.materials.push(mat);
+      return mat;
+    });
+  }));
+};
+
+TextureSimple.prototype.get = function(index) {
+  if (index == null) return this.materials;
+  if (typeof index === 'number') {
+    index = this.materialIndex[index];
+  } else {
+    index = this.materialIndex[this.findIndex(index) - 1];
+  }
+  return this.materials.slice(index[0], index[1]);
+};
+
+TextureSimple.prototype.find = function(name) {
+  for (var i = 0; i < this.materials.length; i++) {
+    if (name === this.materials[i].name) return i;
+  }
+  return -1;
+};
+
+TextureSimple.prototype.findIndex = function(name) {
+  var index = this.find(name);
+  for (var i = 0; i < this.materialIndex.length; i++) {
+    var idx = this.materialIndex[i];
+    if (index >= idx[0] && index < idx[1]) {
+      return i + 1;
+    }
+  }
+  return 0;
+};
+
+TextureSimple.prototype._expandName = function(name) {
+  if (name.top) return [name.back, name.front, name.top, name.bottom, name.left, name.right];
+  if (!isArray(name)) name = [name];
+  // load the 0 texture to all
+  if (name.length === 1) name = [name[0],name[0],name[0],name[0],name[0],name[0]];
+  // 0 is top/bottom, 1 is sides
+  if (name.length === 2) name = [name[1],name[1],name[0],name[0],name[1],name[1]];
+  // 0 is top, 1 is bottom, 2 is sides
+  if (name.length === 3) name = [name[2],name[2],name[0],name[1],name[2],name[2]];
+  // 0 is top, 1 is bottom, 2 is front/back, 3 is left/right
+  if (name.length === 4) name = [name[2],name[2],name[0],name[1],name[3],name[3]];
+  return name;
+};
+
+TextureSimple.prototype._options = function(opts) {
+  opts = opts || {};
+  opts.materialType = opts.materialType || this.materialType;
+  opts.materialParams = defaults(opts.materialParams || {}, this._materialDefaults, this.materialParams);
+  opts.applyTextureParams = opts.applyTextureParams || this.applyTextureParams;
+  return opts;
+};
+
+TextureSimple.prototype.paint = function(geom) {
+  var self = this;
+  geom.faces.forEach(function(face, i) {
+    var index = Math.floor(face.color.b*255 + face.color.g*255*255 + face.color.r*255*255*255);
+    index = self.materialIndex[Math.floor(Math.max(0, index - 1) % self.materialIndex.length)][0];
+
+    // BACK, FRONT, TOP, BOTTOM, LEFT, RIGHT
+    if      (face.normal.z === 1)  index += 1;
+    else if (face.normal.y === 1)  index += 2;
+    else if (face.normal.y === -1) index += 3;
+    else if (face.normal.x === -1) index += 4;
+    else if (face.normal.x === 1)  index += 5;
+
+    face.materialIndex = index;
+  });
+};
+
+TextureSimple.prototype.sprite = function(name, w, h, cb) {
+  var self = this;
+  if (typeof w === 'function') { cb = w; w = null; }
+  if (typeof h === 'function') { cb = h; h = null; }
+  w = w || 16; h = h || w;
+  var img = new Image();
+  img.src = self.texturePath + ext(name);
+  img.onerror = cb;
+  img.onload = function() {
+    var textures = [];
+    for (var x = 0; x < img.width; x += w) {
+      for (var y = 0; y < img.height; y += h) {
+        var canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        var ctx = canvas.getContext('2d');
+        ctx.drawImage(img, x, y, w, h, 0, 0, w, h);
+        var tex = new self.THREE.Texture(canvas);
+        tex.name = name + '_' + x + '_' + y;
+        tex.needsUpdate = true;
+        textures.push(tex);
+      }
+    }
+    cb(null, textures);
+  };
+  return self;
+};
+
+TextureSimple.prototype.animate = function(names, delay) {
+  var self = this;
+  delay = delay || 1000;
+  names = names.map(function(name) {
+    return (typeof name === 'string') ? self.find(name) : name;
+  }).filter(function(name) {
+    return (name !== -1);
+  });
+  if (names.length < 2) return false;
+  if (self._clock == null) self._clock = new self.THREE.Clock();
+  var mat = self.materials[names[0]].clone();
+  self.materials.push(mat);
+  names = [self.materials.length - 1, delay, 0].concat(names);
+  self._animations.push(names);
+  return mat;
+};
+
+TextureSimple.prototype.tick = function() {
+  var self = this;
+  if (self._animations.length < 1 || self._clock == null) return false;
+  var t = self._clock.getElapsedTime();
+  self._animations.forEach(function(anim) {
+    var mats = anim.slice(3);
+    var i = Math.round(t / (anim[1] / 1000)) % (mats.length);
+    if (anim[2] !== i) {
+      self.materials[anim[0]].map = self.materials[mats[i]].map;
+      self.materials[anim[0]].needsUpdate = true;
+      anim[2] = i;
+    }
+  });
+};
+
+TextureSimple.prototype._isTransparent = function(material) {
+  if (!material.map) return;
+  if (!material.map.image) return;
+  if (material.map.image.nodeName.toLowerCase() === 'img') {
+    material.map.image.onload = function() {
+      if (transparent(this)) {
+        material.transparent = true;
+        material.needsUpdate = true;
+      }
+    };
+  } else {
+    if (transparent(material.map.image)) {
+      material.transparent = true;
+      material.needsUpdate = true;
+    }
+  }
+};
+
+function ext(name) {
+  return (String(name).indexOf('.') !== -1) ? name : name + '.png';
+}
+
+// copied from https://github.com/joyent/node/blob/master/lib/util.js#L433
+function isArray(ar) {
+  return Array.isArray(ar) || (typeof ar === 'object' && Object.prototype.toString.call(ar) === '[object Array]');
+}
+
+function hasSubArray(ar) {
+  var has = false;
+  ar.forEach(function(a) { if (isArray(a)) { has = true; return false; } });
+  return has;
+}
+
+function defaults(obj) {
+  [].slice.call(arguments, 1).forEach(function(from) {
+    if (from) for (var k in from) if (obj[k] == null) obj[k] = from[k];
+  });
+  return obj;
 }

--- a/index.js
+++ b/index.js
@@ -85,6 +85,8 @@ function Texture(game, opts) {
 }
 
 Texture.prototype.load = function(names, done) {
+  if (!names || names.length === 0) return;
+
   var self = this;
   if (!Array.isArray(names)) names = [names];
   done = done || function() {};
@@ -416,6 +418,8 @@ function TextureSimple(game, opts) {
 }
 
 TextureSimple.prototype.load = function(names, opts) {
+  if (!names || names.length === 0) return;
+
   var self = this;
   opts = self._options(opts);
   if (!Array.isArray(names)) names = [names];

--- a/index.js
+++ b/index.js
@@ -36,26 +36,26 @@ function Texture(game, opts) {
   var useFlatColors = opts.materialFlatColor === true;
   delete opts.materialFlatColor;
 
-  this.options = defaults(opts || {}, {
+  this.options = {
     crossOrigin: 'Anonymous',
-    materialParams: defaults(opts.materialParams || {}, {
+    materialParams: {
       ambient: 0xbbbbbb,
       transparent: false,
-      side: this.THREE.DoubleSide,
-    }),
-    materialTransparentParams: defaults(opts.materialTransparentParams || {}, {
+      side: this.THREE.DoubleSide
+    },
+    materialTransparentParams: {
       ambient: 0xbbbbbb,
       transparent: true,
       side: this.THREE.DoubleSide,
       //depthWrite: false,
       //depthTest: false
-    }),
+    },
     materialType: this.THREE.MeshLambertMaterial,
     applyTextureParams: function(map) {
       map.magFilter = self.THREE.NearestFilter;
       map.minFilter = self.THREE.LinearMipMapLinearFilter;
     }
-  });
+  };
 
   // create a canvas for the texture atlas
   this.canvas = (typeof document !== 'undefined') ? document.createElement('canvas') : {};
@@ -388,13 +388,6 @@ function uvinvert(coords) {
 
 function ext(name) {
   return (String(name).indexOf('.') !== -1) ? name : name + '.png';
-}
-
-function defaults(obj) {
-  [].slice.call(arguments, 1).forEach(function(from) {
-    if (from) for (var k in from) if (obj[k] == null) obj[k] = from[k];
-  });
-  return obj;
 }
 
 function each(arr, it, done) {

--- a/index.js
+++ b/index.js
@@ -63,8 +63,7 @@ function Texture(game, opts) {
 
       uniforms: {
         tileMap: {type: 't', value: this.texture},
-        tileSize: {type: 'f', value: 16.0},  // size of one individual texture tile
-        tileSizeUV: {type: 'f', value: 16.0 / this.canvas.width}, // size of tile in UV units (0.0-1.0)
+        tileSize: {type: 'f', value: 16.0 / this.canvas.width} // size of tile in UV units (0.0-1.0), square (=== 16.0 / this.canvas.height)
       },
       vertexShader: [
 'varying vec3 vNormal;',
@@ -80,9 +79,8 @@ function Texture(game, opts) {
 '}'
         ].join('\n'),
       fragmentShader: [
-'uniform float tileSize;',
 'uniform sampler2D tileMap;',
-'uniform float tileSizeUV;',
+'uniform float tileSize;', // Size of a tile in atlas
 'uniform vec2 tileOffsets[7];',
 '',
 'varying vec3 vNormal;',
@@ -96,7 +94,6 @@ function Texture(game, opts) {
 
 'vec4 fourTapSample(vec2 tileOffset, //Tile offset in the atlas ',
 '                  vec2 tileUV, //Tile coordinate (as above)',
-'                  float tileSize, //Size of a tile in atlas',
 '                  sampler2D atlas) {',
 '  //Initialize accumulators',
 '  vec4 color = vec4(0.0, 0.0, 0.0, 0.0);',
@@ -155,11 +152,10 @@ function Texture(game, opts) {
   ? [
     '     gl_FragColor = fourTapSample(tileOffset, //Tile offset in the atlas ',
     '                  tileUV, //Tile coordinate (as above)',
-    '                  tileSizeUV, //Size of a tile in atlas',
     '                  tileMap);'].join('\n') 
   : [
     // index tile at offset into texture atlas
-    'vec2 texCoord = tileOffset + tileSizeUV * fract(tileUV);',
+    'vec2 texCoord = tileOffset + tileSize * fract(tileUV);',
     'gl_FragColor = texture2D(tileMap, texCoord);'].join('\n')),
 '',
 '   if (gl_FragColor.a < 0.001) discard; // transparency',
@@ -420,7 +416,7 @@ Texture.prototype.paint = function(mesh, materials) {
     // pass texture start in UV coordinates
     for (var j = 0; j < mesh.geometry.faceVertexUvs[0][i].length; j++) {
       //mesh.geometry.faceVertexUvs[0][i][j].set(atlasuv[j][0], 1 - atlasuv[j][1]);
-      mesh.geometry.faceVertexUvs[0][i][j].set(topUV[0], 1.0 - topUV[1]); // set all to top (fixed tileSizeUV)
+      mesh.geometry.faceVertexUvs[0][i][j].set(topUV[0], 1.0 - topUV[1]); // set all to top (fixed tileSize)
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -645,7 +645,8 @@ function TextureSimple(game, opts) {
   this.THREE              = this.game.THREE || opts.THREE;
   this.materials          = [];
   this.names              = [];
-  this.texturePath        = opts.texturePath    || '/textures/';
+  this.artPacks = opts.artPacks;
+  if (!this.artPacks) throw new Error('voxel-texture requires artPacks option');
   this.materialIndex      = [];
   this._animations        = [];
 
@@ -672,7 +673,7 @@ TextureSimple.prototype.load = function(names, opts) {
         var map = n;
         n = n.name;
       } else if (typeof n === 'string') {
-        var map = self.THREE.ImageUtils.loadTexture(self.texturePath + ext(n));
+        var map = self.THREE.ImageUtils.loadTexture(self.artPacks.getTexture(n));
       } else {
         var map = new self.THREE.Texture(n);
         n = map.name;
@@ -760,10 +761,7 @@ TextureSimple.prototype.sprite = function(name, w, h, cb) {
   if (typeof w === 'function') { cb = w; w = null; }
   if (typeof h === 'function') { cb = h; h = null; }
   w = w || 16; h = h || w;
-  var img = new Image();
-  img.src = self.texturePath + ext(name);
-  img.onerror = cb;
-  img.onload = function() {
+  self.artPacks.getTextureImage(name, function(img) {
     var textures = [];
     for (var x = 0; x < img.width; x += w) {
       for (var y = 0; y < img.height; y += h) {
@@ -778,7 +776,9 @@ TextureSimple.prototype.sprite = function(name, w, h, cb) {
       }
     }
     cb(null, textures);
-  };
+  }, function(err, img) {
+    console.log('TextureSimple sprite '+name+' error '+err+' on '+img);
+  });
   return self;
 };
 

--- a/index.js
+++ b/index.js
@@ -13,11 +13,20 @@ module.exports = function(game, opts) {
     return new TextureSimple(game, opts);
 };
 
+function reconfigure(old) {
+  var ret = module.exports(old.game, old.opts);
+  ret.load(old.names);
+
+  return ret;
+}
+
 function Texture(game, opts) {
   if (!(this instanceof Texture)) return new Texture(game, opts || {});
   var self = this;
   this.game = game;
+  this.opts = opts;
   this.THREE = this.game.THREE;
+  this.names = [];
   this.materials = [];
   this.transparents = [];
   this.texturePath = opts.texturePath || '/textures/';
@@ -84,8 +93,13 @@ function Texture(game, opts) {
   this._meshQueue = [];
 }
 
+Texture.prototype.reconfigure = function() {
+  return reconfigure(this);
+};
+
 Texture.prototype.load = function(names, done) {
   if (!names || names.length === 0) return;
+  this.names = this.names.concat(names); // save for reconfiguration
 
   var self = this;
   if (!Array.isArray(names)) names = [names];
@@ -401,8 +415,10 @@ function TextureSimple(game, opts) {
   if (!(this instanceof TextureSimple)) return new TextureSimple(game, opts || {});
   var self = this;
   this.game = game;
+  this.opts = opts;
   this.THREE              = this.game.THREE || opts.THREE || require('three');
   this.materials          = [];
+  this.names              = [];
   this.texturePath        = opts.texturePath    || '/textures/';
   this.materialParams     = opts.materialParams || {};
   this.materialType       = opts.materialType   || this.THREE.MeshLambertMaterial;
@@ -417,8 +433,13 @@ function TextureSimple(game, opts) {
   }
 }
 
+TextureSimple.prototype.reconfigure = function() {
+  return reconfigure(this);
+};
+
 TextureSimple.prototype.load = function(names, opts) {
   if (!names || names.length === 0) return;
+  this.names = this.names.concat(names); // save for reconfiguration
 
   var self = this;
   opts = self._options(opts);

--- a/index.js
+++ b/index.js
@@ -415,23 +415,27 @@ function TextureSimple(game, opts) {
   if (!(this instanceof TextureSimple)) return new TextureSimple(game, opts || {});
   var self = this;
   this.game = game;
-  this.opts = opts;
-  this.THREE              = this.game.THREE || opts.THREE || require('three');
-  this.materials          = [];
-  this.names              = [];
-  this.texturePath        = opts.texturePath    || '/textures/';
-  this.materialParams     = opts.materialParams || {};
-  this.materialType       = opts.materialType   || this.THREE.MeshLambertMaterial;
-  this.materialIndex      = [];
-  this._animations        = [];
-  this._materialDefaults  = { ambient: 0xbbbbbb };
-  this.applyTextureParams = opts.applyTextureParams || function(map) {
+
+  opts = opts || {};
+  this.materialType = opts.materialType = opts.materialType || this.THREE.MeshLambertMaterial;
+  this.materialParams = opts.materialParams = opts.materialParams || {};
+  this._materialDefaults = opts.materialDefaults = opts.materialDefaults ||{ ambient: 0xbbbbbb };
+  this.applyTextureParams = opts.applyTextureParams = opts.applyTextureParams || function(map) {
     map.magFilter = self.THREE.NearestFilter;
     map.minFilter = self.THREE.LinearMipMapLinearFilter;
     map.wrapT     = self.THREE.RepeatWrapping;
     map.wrapS     = self.THREE.RepeatWrapping;
-  }
-}
+  };
+
+  this.THREE              = this.game.THREE || opts.THREE || require('three');
+  this.materials          = [];
+  this.names              = [];
+  this.texturePath        = opts.texturePath    || '/textures/';
+  this.materialIndex      = [];
+  this._animations        = [];
+
+  this.opts = opts;
+};
 
 TextureSimple.prototype.reconfigure = function() {
   return reconfigure(this);
@@ -442,7 +446,7 @@ TextureSimple.prototype.load = function(names, opts) {
   this.names = this.names.concat(names); // save for reconfiguration
 
   var self = this;
-  opts = self._options(opts);
+  opts = self.opts;
   if (!Array.isArray(names)) names = [names];
   if (!hasSubArray(names)) names = [names];
   return [].concat.apply([], names.map(function(name) {
@@ -513,14 +517,6 @@ TextureSimple.prototype._expandName = function(name) {
   // 0 is top, 1 is bottom, 2 is front/back, 3 is left/right
   if (name.length === 4) name = [name[2],name[2],name[0],name[1],name[3],name[3]];
   return name;
-};
-
-TextureSimple.prototype._options = function(opts) {
-  opts = opts || {};
-  opts.materialType = opts.materialType || this.materialType;
-  opts.materialParams = defaults(opts.materialParams || {}, this._materialDefaults, this.materialParams);
-  opts.applyTextureParams = opts.applyTextureParams || this.applyTextureParams;
-  return opts;
 };
 
 TextureSimple.prototype.paintMesh = function(mesh) {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function Texture(game, opts) {
 
   // create core atlas and texture
   this.atlas = createAtlas(this.canvas);
-  this.atlas.tilepad = !this.useFourTap; // for 4-tap, not using tilepad since it repeats only half on each side (.5 .5 .5 / .5 1 .5 / .5 .5 .5, not 1 1 / 1 1)
+  this.atlas.tilepad = true;
   this._atlasuv = false;
   this._atlaskey = false;
   this.texture = new this.THREE.Texture(this.canvas);

--- a/index.js
+++ b/index.js
@@ -211,8 +211,8 @@ function Texture(game, opts) {
 '                      dot(vNormal.yzx, vPosition));',
 
 '',
-'    // back: flip 180',
-'    if (vNormal.z < 0.0) tileUV.t = 1.0 - tileUV.t;',
+'    // back and bottom: flip 180',
+'    if (vNormal.z < 0.0 || vNormal.y < 0.0) tileUV.t = 1.0 - tileUV.t;',
 '',
 '    // left: rotate 90 ccw',
 '    if (vNormal.x < 0.0) {',
@@ -221,12 +221,16 @@ function Texture(game, opts) {
 '        tileUV.t = 1.0 - r;',
 '    }',
 '',
-'    // right: rotate 90 cw',
-'    if (vNormal.x > 0.0) {',
+'    // right and top: rotate 90 cw',
+'    if (vNormal.x > 0.0 || vNormal.y > 0.0) {',
 '        float r = tileUV.s;',
 '        tileUV.s = tileUV.t;',
 '        tileUV.t = r;',
-'    }', // TODO: might technically need to mirror-image other sides? (can't really tell)
+'    }', 
+'',
+'    // front and back and bottom: flip 180',
+'   if (vNormal.z > 0.0 || vNormal.z < 0.0 || vNormal.y < 0.0) tileUV.s = 1.0 - tileUV.s;',
+'',
 '',
 
 // three.js' UV coordinate is passed as tileOffset, starting point determining the texture

--- a/index.js
+++ b/index.js
@@ -395,8 +395,6 @@ function each(arr, it, done) {
 // Support for textures without atlas ("simple" textures), as in 0.4.0
 ////
 
-var transparent = require('opaque').transparent;
-
 function TextureSimple(opts) {
   var self = this;
   if (!(this instanceof TextureSimple)) return new TextureSimple(opts || {});
@@ -418,7 +416,7 @@ function TextureSimple(opts) {
 TextureSimple.prototype.load = function(names, opts) {
   var self = this;
   opts = self._options(opts);
-  if (!isArray(names)) names = [names];
+  if (!Array.isArray(names)) names = [names];
   if (!hasSubArray(names)) names = [names];
   return [].concat.apply([], names.map(function(name) {
     name = self._expandName(name);
@@ -478,7 +476,7 @@ TextureSimple.prototype.findIndex = function(name) {
 
 TextureSimple.prototype._expandName = function(name) {
   if (name.top) return [name.back, name.front, name.top, name.bottom, name.left, name.right];
-  if (!isArray(name)) name = [name];
+  if (!Array.isArray(name)) name = [name];
   // load the 0 texture to all
   if (name.length === 1) name = [name[0],name[0],name[0],name[0],name[0],name[0]];
   // 0 is top/bottom, 1 is sides
@@ -583,37 +581,22 @@ TextureSimple.prototype._isTransparent = function(material) {
   if (!material.map.image) return;
   if (material.map.image.nodeName.toLowerCase() === 'img') {
     material.map.image.onload = function() {
-      if (transparent(this)) {
+      if (isTransparent(this)) {
         material.transparent = true;
         material.needsUpdate = true;
       }
     };
   } else {
-    if (transparent(material.map.image)) {
+    if (isTransparent(material.map.image)) {
       material.transparent = true;
       material.needsUpdate = true;
     }
   }
 };
 
-function ext(name) {
-  return (String(name).indexOf('.') !== -1) ? name : name + '.png';
-}
-
-// copied from https://github.com/joyent/node/blob/master/lib/util.js#L433
-function isArray(ar) {
-  return Array.isArray(ar) || (typeof ar === 'object' && Object.prototype.toString.call(ar) === '[object Array]');
-}
-
 function hasSubArray(ar) {
   var has = false;
-  ar.forEach(function(a) { if (isArray(a)) { has = true; return false; } });
+  ar.forEach(function(a) { if (Array.isArray(a)) { has = true; return false; } });
   return has;
 }
 
-function defaults(obj) {
-  [].slice.call(arguments, 1).forEach(function(from) {
-    if (from) for (var k in from) if (obj[k] == null) obj[k] = from[k];
-  });
-  return obj;
-}

--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ function Texture(game, opts) {
 '   vec2 texCoord = tileOffset + tileSizeUV * tileUV;',
 '',
 '   gl_FragColor = texture2D(tileMap, texCoord);',
+'   if (gl_FragColor.a < 0.001) discard; // transparency',
 '}'
 ].join('\n')
     },
@@ -351,7 +352,7 @@ Texture.prototype.paint = function(mesh, materials) {
     if (!atlasuv) return;
 
     // If a transparent texture use transparent material
-    face.materialIndex = (self.transparents.indexOf(name) !== -1) ? 1 : 0;
+    face.materialIndex = 0; //(self.transparents.indexOf(name) !== -1) ? 1 : 0; // XXX: always use same material TODO: do we need separate opaque/transparent?
 
     // 0 -- 1
     // |    |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "opaque": "0.0.1",
     "tic": "~0.2.1",
     "atlaspack": "~0.2.5",
+    "touchup": "~0.0.1",
     "voxel-fakeao": "~0.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gh-pages": "cp -R ./example/* ./ && browserify world.js -o world.js"
   },
   "dependencies": {
+    "opaque": "0.0.1",
     "tic": "~0.2.1",
     "atlaspack": "~0.2.5",
     "voxel-fakeao": "~0.1.1"


### PR DESCRIPTION
This isn't necessarily in a state ready to be pulled yet but I wanted to submit these changes for feedback – several major enhancements here:

**Non-atlas texturing**: restored from v0.4.0 as an option. Most of the time the atlas-based texturing is desirable but having the non-atlas implementation can be useful to switch to for comparison purposes, debugging problems with the atlas texturing, etc. Added as `TextureSimple`, along side the existing `Texture`; may include too much duplication at the moment, but it's there.

**Compatible API & reconfiguring**: to support switching between atlas/non-atlas, adds `getMesh()` and `paintMesh()`, compatible with both. With a change to voxel-engine https://github.com/deathcap/voxel-engine/commit/58967dba81734134f1ad8d52b18d7203eafc27c3 either implementation can be used; specified at initialization with new `useAtlas` or changed afterwards with `reconfigure`: https://github.com/deathcap/voxel-debug/commit/26d9149db9a3a24309cac631e5bc8846521cb743

**Support for greedy meshes / texture tiling**: the main problem with atlases in v0.5.7 is how the UV coordinates are set, per vertex, causing the same texture to be stretched across the entire face of a greedily-meshed voxel – requiring the use of the non-greedy culled mesher instead, but that's much slower to remesh. So I implemented the technique described in http://0fps.wordpress.com/2013/07/09/texture-atlases-wrapping-and-mip-mapping/ - using the fractional part of the position world coordinate as the tile UV. Unfortunately this not all that elegant to implement in three.js, had to use a custom `ShaderMaterial`, but merging in some of three.js's own shader code to support lighting and such. I'm also not entirely clear how one is meant to (or if it is even possible) to assign attributes per geometry (instead of per material, which all the examples use, but we want only one material), so I (ab/re)used three's `faceVertexUvs` for this purpose, it works at least, but perhaps there is a better way (or maybe this is another reason to switch to a more modular graphics library – ndarray/gl-now https://github.com/voxel/issues/issues/4 where adding these kinds of features is easier, or they are already implemented :) e.g. in https://github.com/mikolalysenko/ao-shader)

**4-tap sampling**: fixes the artifacts near the edges due to the above feature (from same article). Repeats the textures 2x2 and takes four samples in the fragment shader (wasn't able to use atlaspack `tilepad` since it pads by half, and this algorithm requires four copies), works very well to fix the texture edges. This feature can also be enabled/disabled by an option `useFourTap` (also configurable in https://github.com/deathcap/voxel-debug/commit/f71ef9ec0e46e93b9ba33b78c93b08031c6cfd3a), mainly for testing purposes.

cheers
