### PR TITLE
Add missing opaque module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gh-pages": "cp -R ./example/* ./ && browserify world.js -o world.js"
   },
   "dependencies": {
+    "opaque": "0.0.1",
     "tic": "~0.2.1",
     "atlaspack": "~0.2.5",
     "voxel-fakeao": "~0.1.1"


### PR DESCRIPTION
Fixes:

```
voxel-texture $ node index.js

module.js:340
    throw err;
          ^
Error: Cannot find module 'opaque'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/private/tmp/node_modules/voxel-texture/index.js:3:21)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
